### PR TITLE
Add CNAME file for switchgui.de

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+switchgui.de


### PR DESCRIPTION
This domain is valid for at least 3 years and of course extendable after that.

Merging this PR will automatically redirect all current links to the new domain. No other changes should be needed outside of potentially needing to modify the single `switch-guide` hard link.