### PR TITLE
Add notice to use sudo on linux + add micro guide for udev rule.

### DIFF
--- a/docs/extras/adding_udev.md
+++ b/docs/extras/adding_udev.md
@@ -1,0 +1,40 @@
+# Linux - Run payload sender without root
+
+This section details how to add an udev rule to let you send a payload to the Nintendo Switch without needing to use `sudo`.
+
+!!! tip ""
+    The following instructions are not for beginners. Only do this if you are confident in what you are doing.
+
+!!! tip ""
+    The following instructions only work if you have `systemd` installed. Most modern distros have `systemd`.
+
+!!! tip ""
+    Do the following instructions while your Switch is _not_ connected to your computer.
+
+## Creating a new group
+
+To start, we will create a new group and add ourselves to it. The group the Nintendo Switch device will be owned by on Linux will be set to this group.
+
+!!! tip ""
+    There are differing implementations of the following commands on different distros. The commands below are assumed to be run on Ubuntu. Check your distros manual if you are not running Ubuntu for the equivalent commands.
+
+1. Open a terminal.
+2. Enter the following command: `sudo groupadd nintendo_switch`.
+3. Enter your password when prompted.
+4. Enter the following command: `sudo usermod -a -G nintendo_switch $USER`. Make sure that the `G` is capitalized!
+5. Close the terminal.
+
+## Adding a udev rule
+
+Next we're gonna add a new udev rule. udev is a device manager for the linux kernel. The rule we're gonna specify is that if the Switch is connected in RCM mode, the group the Switch belongs to will be the group we made in the previous section.
+
+1. Open a terminal.
+2. Change to the root user with the following command: `sudo su`. Enter your password when prompted.
+3. Enter the following command: `mkdir -p /etc/udev/rules.d`.
+4. Enter the following command: `cd /etc/udev/rules.d`.
+5. Enter the following command: `echo 'SUBSYSTEMS=="usb", ATTRS{manufacturer}=="NVIDIA Corp.", ATTRS{product}=="APX", GROUP="nintendo_switch"' > 10-switch.rules`.
+6. Enter the following command: `udevadm control --reload`.
+7. Enter the following command: `udevadm trigger`.
+8. Logout and log back in.
+
+You should now be able to run the payload sender without having to use `sudo`.

--- a/docs/extras/adding_udev.md
+++ b/docs/extras/adding_udev.md
@@ -6,7 +6,7 @@ This section details how to add an udev rule to let you send a payload to the Ni
     The following instructions are not for beginners. Only do this if you are confident in what you are doing.
 
 !!! tip ""
-    The following instructions only work if you have a system that implements `eudev`. Most modern distros come with `systemd` already installed, which includes a `eudev` implementation.
+    The following instructions only work if you have a system that implements `udev`. Most modern distros come with `systemd` already installed, which includes a `udev` implementation.
 
     There are differing implementations of the following commands on different distros. The commands below are assumed to be ran on Ubuntu. Check your distros manual if you are not running Ubuntu for the equivalent commands.
 

--- a/docs/extras/adding_udev.md
+++ b/docs/extras/adding_udev.md
@@ -6,7 +6,9 @@ This section details how to add an udev rule to let you send a payload to the Ni
     The following instructions are not for beginners. Only do this if you are confident in what you are doing.
 
 !!! tip ""
-    The following instructions only work if you have `systemd` installed. Most modern distros have `systemd`.
+    The following instructions only work if you have a system that implements `eudev`. Most modern distros come with `systemd` already installed, which includes a `eudev` implementation.
+
+    There are differing implementations of the following commands on different distros. The commands below are assumed to be ran on Ubuntu. Check your distros manual if you are not running Ubuntu for the equivalent commands.
 
 !!! tip ""
     Do the following instructions while your Switch is _not_ connected to your computer.
@@ -14,9 +16,6 @@ This section details how to add an udev rule to let you send a payload to the Ni
 ## Creating a new group
 
 To start, we will create a new group and add ourselves to it. The group the Nintendo Switch device will be owned by on Linux will be set to this group.
-
-!!! tip ""
-    There are differing implementations of the following commands on different distros. The commands below are assumed to be run on Ubuntu. Check your distros manual if you are not running Ubuntu for the equivalent commands.
 
 1. Open a terminal.
 2. Enter the following command: `sudo groupadd nintendo_switch`.
@@ -31,10 +30,9 @@ Next we're gonna add a new udev rule. udev is a device manager for the linux ker
 1. Open a terminal.
 2. Change to the root user with the following command: `sudo su`. Enter your password when prompted.
 3. Enter the following command: `mkdir -p /etc/udev/rules.d`.
-4. Enter the following command: `cd /etc/udev/rules.d`.
-5. Enter the following command: `echo 'SUBSYSTEMS=="usb", ATTRS{manufacturer}=="NVIDIA Corp.", ATTRS{product}=="APX", GROUP="nintendo_switch"' > 10-switch.rules`.
-6. Enter the following command: `udevadm control --reload`.
-7. Enter the following command: `udevadm trigger`.
-8. Logout and log back in.
+4. Enter the following command: `echo 'SUBSYSTEMS=="usb", ATTRS{manufacturer}=="NVIDIA Corp.", ATTRS{product}=="APX", GROUP="nintendo_switch"' > /etc/udev/rules.d/10-switch.rules`.
+5. Enter the following command: `udevadm control --reload`.
+6. Enter the following command: `udevadm trigger`.
+7. Logout and log back in.
 
 You should now be able to run the payload sender without having to use `sudo`.

--- a/docs/user_guide/sending_payload.md
+++ b/docs/user_guide/sending_payload.md
@@ -40,11 +40,11 @@ Now that the device is in RCM, we will need to send it a payload. The methods ar
 ### Instructions
 
 !!! tip ""
-    1. Download and run the payload injector
+    1. Download and run the payload injector (if you are on Linux, you will need to run this program as root or use `sudo`.)
     2. Connect your Switch in RCM to your PC using the USB cable
     3. Wait for your Switch to be shown as found in the injector
     4. Press `Select Payload`, and navigate to and select your hekate_ctcaer `.bin` file
-    6. Click `Send Payload!` to launch Hekate
+    5. Click `Send Payload!` to launch Hekate
 
 &nbsp;
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
         - 'Save Management': 'extras/save_management.md'
         - 'Game Modding': 'extras/game_modding.md'  
         - 'Giving Homebrew More RAM': 'extras/himem_homebrew.md'      
+        - 'Linux - Run payload sender without root': 'extras/adding_udev.md'
     - FAQ: faq.md
     - About: about.md
     

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,7 @@ nav:
         - 'Save Management': 'extras/save_management.md'
         - 'Game Modding': 'extras/game_modding.md'  
         - 'Giving Homebrew More RAM': 'extras/himem_homebrew.md'      
-        - 'Linux - Run payload sender without root': 'extras/adding_udev.md'
+        - 'Linux injection without root': 'extras/adding_udev.md'
     - FAQ: faq.md
     - About: about.md
     


### PR DESCRIPTION
This PR brings the following changes:

- `user-guide/sending_payload`: Added sudo notice.
- `extras/adding_udev`: New micro guide to add a udev rule to run the payload sender without root.