### PR TITLE
Remove nogc warning

### DIFF
--- a/docs/files/hekate_ipl.ini
+++ b/docs/files/hekate_ipl.ini
@@ -3,4 +3,3 @@ payload=atmosphere/fusee-primary.bin
 
 [Stock]
 { NOTE: This option does not launch CFW. }
-{ NOTE: This option may render your game cartridge reader unusable if you downgrade to a firmware below 4.0. }


### PR DESCRIPTION
Hekate applies it automatically as of the latest release.