### PR TITLE
Atmosphere now bundles the Homebrew menu + Loader

### DIFF
--- a/docs/user_guide/sd_preparation.md
+++ b/docs/user_guide/sd_preparation.md
@@ -16,8 +16,6 @@ Atmosphere has its own bootloader, called fusee (primary). For the purposes of t
     - The latest release of [Hekate](https://github.com/CTCaer/hekate/releases/)
     - The latest release of [Atmosphere](https://github.com/Atmosphere-NX/Atmosphere/releases) 
         - You will need to download both the release zip and the `fusee-primary.bin`
-    - The latest release of [nx-hbmenu](https://github.com/switchbrew/nx-hbmenu/releases)
-    - The latest release of [nx-hbloader](https://github.com/switchbrew/nx-hbloader/releases)
     - The latest release of [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases)
 	    - Download the `Checkpoint.nro` release of Checkpoint
     - The latest release of [FTPD](https://github.com/mtheall/ftpd/releases)
@@ -34,11 +32,8 @@ Atmosphere has its own bootloader, called fusee (primary). For the purposes of t
     2. Copy *the contents of* the Atmosphere `.zip` file to the root of your SD card
     3. Copy `fusee-primary.bin` to the atmosphere folder on your SD card
     4. Copy the `bootloader` folder from the Hekate `.zip` file to the root of your SD card
-    5. Copy nx-hbloader (`hbl.nsp`) to the `atmosphere` folder on your SD card
-    6. Copy *the contents of* the nx-hbmenu `.zip` file to the root of your SD card
-    7. Copy `hekate-ipl.ini` to the `bootloader` folder on your SD card
-    8. Make a folder called `switch` on the root of the sd card
-    9. Copy `ftpd.nro` , `Checkpoint.nro` and `NX-Shell.nro` to the `switch` folder
+    5. Copy `hekate-ipl.ini` to the `bootloader` folder on your SD card
+    6. Copy `ftpd.nro` , `Checkpoint.nro` and `NX-Shell.nro` to the `switch` folder on your SD card
 
 &nbsp;
 


### PR DESCRIPTION
Change brought about by Atmosphere 0.8.5 -> Atmosphere now contains nx-hbmenu and nx-hbloader in it's release packages, so no need to download those anymore.

I'd personally recommend keeping nx-hbmenu and nx-hbloader in the about page, as it's still used, they just don't have to be manually set up anymore.

Also removed the creation of the `switch` folder, as the reboot_to_payload.nro file in the Atmosphere release means that this folder should already exist when setting things up.