### PR TITLE
Move the guide over to FSS0 for booting cfw too.

### DIFF
--- a/docs/extras/alternate_bootsetups.md
+++ b/docs/extras/alternate_bootsetups.md
@@ -37,7 +37,7 @@ If you need to troubleshoot something, or need to try a different boot setup, re
     - The latest release of [Atmosphere](https://github.com/Atmosphere-NX/Atmosphere/releases) 
         - You will need to download both the release zip and the `fusee-primary.bin`
     
-# Instructions
+### Instructions
  
 !!! tip ""
     1. Insert your Switch's SD card into your PC

--- a/docs/extras/alternate_bootsetups.md
+++ b/docs/extras/alternate_bootsetups.md
@@ -25,7 +25,7 @@ If you need to troubleshoot something, or need to try a different boot setup, re
     3. Copy `fusee-primary.bin` to the atmosphere folder on your SD card
     4. Copy the `bootloader` folder from the Hekate `.zip` file to the root of your SD card
     5. Copy `hekate-ipl.ini` to the `bootloader` folder on your SD card
-    6. Setup is complete, now you can boot CFW by injecting `hekate.bin`
+    6. Setup is complete, now you can boot CFW by injecting the hekate_ctcaer `.bin` file from the Hekate zip
 
 
 &nbsp;

--- a/docs/extras/alternate_bootsetups.md
+++ b/docs/extras/alternate_bootsetups.md
@@ -1,0 +1,45 @@
+# Alternate boot setups
+
+If you need to troubleshoot something, or need to try a different boot setup, read on.
+
+!!! danger "Do I need any of these?"
+	Unless you are experiencing problems with booting or Atmosphere itself, it's strongly recommended to use the main guide instead of these. They are provided for the sake of completeness.
+
+&nbsp;
+
+### Chainloading Fusee-primary from Hekate
+
+
+!!! tip "What you need"
+    - The latest release of [Hekate](https://github.com/CTCaer/hekate/releases/)
+    - The latest release of [Atmosphere](https://github.com/Atmosphere-NX/Atmosphere/releases) 
+        - You will need to download both the release zip and the `fusee-primary.bin`
+    - <a href="../../files/extras/hekate_ipl.ini" download>hekate-ipl.ini</a>
+    
+    
+### Instructions
+
+!!! tip ""
+    1. Insert your Switch's SD card into your PC
+    2. Copy *the contents of* the Atmosphere `.zip` file to the root of your SD card
+    3. Copy `fusee-primary.bin` to the atmosphere folder on your SD card
+    4. Copy the `bootloader` folder from the Hekate `.zip` file to the root of your SD card
+    5. Copy `hekate-ipl.ini` to the `bootloader` folder on your SD card
+    6. Setup is complete, now you can boot CFW by injecting `hekate.bin`
+
+
+&nbsp;
+
+### Using Fusee-primary without Hekate
+
+
+!!! tip "What you need"
+    - The latest release of [Atmosphere](https://github.com/Atmosphere-NX/Atmosphere/releases) 
+        - You will need to download both the release zip and the `fusee-primary.bin`
+    
+# Instructions
+ 
+!!! tip ""
+    1. Insert your Switch's SD card into your PC
+    2. Copy *the contents of* the Atmosphere `.zip` file to the root of your SD card
+    3. Setup is complete, now you can boot CFW by injecting `fusee-primary.bin`

--- a/docs/files/extras/hekate_ipl.ini
+++ b/docs/files/extras/hekate_ipl.ini
@@ -1,7 +1,7 @@
 {------ Atmosphere ------}
 {Pick this option to launch CFW.}
 [Atmosphere]
-fss0=atmosphere/fusee-secondary.bin
+payload=atmosphere/fusee-primary.bin
 { }
 {------ Stock ------}
 {NOTE: This option does not launch CFW.}

--- a/docs/files/hekate_ipl.ini
+++ b/docs/files/hekate_ipl.ini
@@ -1,6 +1,6 @@
 {------ Atmosphere ------}
 {Pick this option to launch CFW.}
-[Atmosphere]
+[Atmosphere FSS0]
 fss0=atmosphere/fusee-secondary.bin
 { }
 {------ Stock ------}

--- a/docs/user_guide/launching_cfw.md
+++ b/docs/user_guide/launching_cfw.md
@@ -11,7 +11,7 @@ Unlike systems such as the DSi, Wii, or 3DS, Switch CFW is currently volatile- i
 !!! tip ""
     1. Power on your Switch into RCM, and upload the Hekate payload
     2. Navigate to `Launch firmware` with the volume buttons, and press the power button to confirm
-    3. Navigate to `Atmosphere` with the volume buttons, and press the power button to confirm
+    3. Navigate to `Atmosphere FSS0` with the volume buttons, and press the power button to confirm
 
 Your switch is now booting into Atmosphere.
 

--- a/docs/user_guide/sd_preparation.md
+++ b/docs/user_guide/sd_preparation.md
@@ -15,7 +15,7 @@ Atmosphere has its own bootloader, called fusee (primary). For the purposes of t
 !!! tip ""
     - The latest release of [Hekate](https://github.com/CTCaer/hekate/releases/)
     - The latest release of [Atmosphere](https://github.com/Atmosphere-NX/Atmosphere/releases) 
-        - You will need to download both the release zip and the `fusee-primary.bin`
+        - You will need to download the release zip.
     - The latest release of [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases)
 	    - Download the `Checkpoint.nro` release of Checkpoint
     - The latest release of [FTPD](https://github.com/mtheall/ftpd/releases)
@@ -30,7 +30,6 @@ Atmosphere has its own bootloader, called fusee (primary). For the purposes of t
 !!! tip ""
     1. Insert your Switch's SD card into your PC
     2. Copy *the contents of* the Atmosphere `.zip` file to the root of your SD card
-    3. Copy `fusee-primary.bin` to the atmosphere folder on your SD card
     4. Copy the `bootloader` folder from the Hekate `.zip` file to the root of your SD card
     5. Copy `hekate-ipl.ini` to the `bootloader` folder on your SD card
     6. Copy `ftpd.nro` , `Checkpoint.nro` and `NX-Shell.nro` to the `switch` folder on your SD card

--- a/docs/user_guide/sd_preparation.md
+++ b/docs/user_guide/sd_preparation.md
@@ -30,9 +30,9 @@ Atmosphere has its own bootloader, called fusee (primary). For the purposes of t
 !!! tip ""
     1. Insert your Switch's SD card into your PC
     2. Copy *the contents of* the Atmosphere `.zip` file to the root of your SD card
-    4. Copy the `bootloader` folder from the Hekate `.zip` file to the root of your SD card
-    5. Copy `hekate-ipl.ini` to the `bootloader` folder on your SD card
-    6. Copy `ftpd.nro` , `Checkpoint.nro` and `NX-Shell.nro` to the `switch` folder on your SD card
+    3. Copy the `bootloader` folder from the Hekate `.zip` file to the root of your SD card
+    4. Copy `hekate-ipl.ini` to the `bootloader` folder on your SD card
+    5. Copy `ftpd.nro` , `Checkpoint.nro` and `NX-Shell.nro` to the `switch` folder on your SD card
 
 &nbsp;
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
         - 'Game Modding': 'extras/game_modding.md'  
         - 'Giving Homebrew More RAM': 'extras/himem_homebrew.md'      
         - 'Linux injection without root': 'extras/adding_udev.md'
+        - 'Alternate Boot Setups': 'extras/alternate_bootsetups.md
     - FAQ: faq.md
     - About: about.md
     

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ nav:
         - 'Game Modding': 'extras/game_modding.md'  
         - 'Giving Homebrew More RAM': 'extras/himem_homebrew.md'      
         - 'Linux injection without root': 'extras/adding_udev.md'
-        - 'Alternate Boot Setups': 'extras/alternate_bootsetups.md
+        - 'Alternate Boot Setups': 'extras/alternate_bootsetups.md'
     - FAQ: faq.md
     - About: about.md
     


### PR DESCRIPTION
Changes:
* Created a new extra called "Alternate boot setups"

* Hekate -> fusee-primary chainload has been moved to the new section, with the addition of a new extra hekate_ipl.ini which uses the old boot process

* Added a guide on how to use Fusee-primary without Hekate for the sake of completion, in case it's desired to set up an official boot chain without Hekate.

* Changed main guide to use FSS0 (mainly just wording and a quick ini change) for CFW too