### PR TITLE
emummc: partitioning_sd: add instructions for macOS

### DIFF
--- a/docs/user_guide/emummc/partitioning_sd.md
+++ b/docs/user_guide/emummc/partitioning_sd.md
@@ -74,4 +74,21 @@
 	4. Wait until it finishes running. Depending on the size of your microSD card, this might take a while.
 	5. Run `sudo fatlabel <value> "sMicroSD"`. Enter your password if prompted. Replace `<value>` with the value you got from step 2.
 
+-----
+## macOS instructions
+
+!!! danger "SD card identification"
+	Make 100% sure you get your microSD card during the following steps. If you are not careful, you can end up wiping the wrong disk. We are not responsible for data loss when doing this.
+
+### What you will need (macOS)
+
+- Access to an administrator account.
+
+### Instructions (macOS)
+
+1. Open Terminal at `/Applications/Terminal.app`.
+2. Run `diskutil list`. This will print information about all drives connected to your Mac. Use the information about the disk size to identify your microSD card. Use the device name such as `/dev/disk#` when partitioning the microSD card.
+3. Run the following command to partition the disk. Ensure that the device name is replaced with the one for your disk.  
+`diskutil partitionDisk disk# MBR ms-dos SMICROSD R ms-dos EMUMMC 61124608S`
+
 #### [Continue to SD Preperations <i class="fa fa-arrow-circle-right fa-lg"></i>](sd_preparation.md)


### PR DESCRIPTION
This adds steps for macOS users, using diskutil to partition the SD
card. This creates an EMUMMC volume that is 61120512 sectors, or
31293702144 bytes (29.14 GiB). (An additional 4096 sectors are added to
the command, as diskutil removes this amount when partitioning for some
reason.)