### PR TITLE
Fixed broken link

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -110,7 +110,7 @@
 !!! tip ""
     This is an issue primarily affecting macOS users, but may occur on other devices as well. If you are able to launch the homebrew menu, but you are not seeing some or any of your homebrew, you will need to unset the archive bit with Hekate.
 
-    1. [Send the Hekate payload to your Switch](../user_guide/sending_payload/).
+    1. [Send the Hekate payload to your Switch](../user_guide/emummc/sending_payload/).
     2. Navigate to `Tools` with the volume buttons and press power to confirm.
     3. Navigate to `Fix archive bit (except Nintendo folder)` with the volume buttons and press power to confirm.
     4. Wait a bit, this may take a while.

--- a/docs/user_guide/emummc/entering_rcm.md
+++ b/docs/user_guide/emummc/entering_rcm.md
@@ -17,7 +17,7 @@ There are several methods of entering RCM (**R**e**C**overy **M**ode). The most 
 ### Instructions
 
 !!! tip ""
-    1. Power off the Switch and use one of the methods listed below to short the pins.
+    1. Power off the Switch and use one of the methods listed below to short the pins on the right joycon rail.
     2. Hold Volume Up and press the Power button.
 
     If your Switch displays the Nintendo logo and boots normally or immediately shuts down, you didn't successfully enter RCM and should try again. Otherwise, if your console did not turn on normally, and the screen remained black with no backlight, your Switch is in RCM.

--- a/docs/user_guide/sysnand/entering_rcm.md
+++ b/docs/user_guide/sysnand/entering_rcm.md
@@ -17,7 +17,7 @@ There are several methods of entering RCM (**R**e**C**overy **M**ode). The most 
 ### Instructions
 
 !!! tip ""
-    1. Power off the Switch and use one of the methods listed below to short the pins.
+    1. Power off the Switch and use one of the methods listed below to short the pins on the right joycon rail.
     2. Hold Volume Up and press the Power button.
 
     If your Switch displays the Nintendo logo and boots normally or immediately shuts down, you didn't successfully enter RCM and should try again. Otherwise, if your console did not turn on normally, and the screen remained black with no backlight, your Switch is in RCM.


### PR DESCRIPTION
Fixed a broken link in the FAQ that links to the entering RCM page.