### PR TITLE
Add wifi warning to the section before entering RCM

### DIFF
--- a/docs/user_guide/emummc/entering_rcm.md
+++ b/docs/user_guide/emummc/entering_rcm.md
@@ -16,6 +16,9 @@ There are several methods of entering RCM (**R**e**C**overy **M**ode). The most 
 
 ### Instructions
 
+!!!warning "Before you start"
+    Before you start, boot your switch normally, and delete all the wifi networks. You can add them back to your sysnand after completing this guide
+
 !!! tip ""
     1. Power off the Switch and use one of the methods listed below to short the pins on the right joycon rail.
     2. Hold Volume Up and press the Power button.


### PR DESCRIPTION
Figured it'd make sense to include the warning on what to do before entering RCM before the part where we enter RCM and not after 😬 
just bit me in the ass, finally managed to enter RCM with my makeshift paperclip jig and then I read about deleting wifi networks on the next page…