### PR TITLE
Update changes for the firmware table with exploits.

### DIFF
--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -73,15 +73,17 @@ The following information is based on [this GBATemp thread](https://gbatemp.net/
 
 &nbsp;
 
-| Firmware Version | Unpatched Switches (HAC-001) | Patched Switches (HAC-001) | "New" Switch (HAC-001-01)   | Switch Lite (HOH-001)  | 
+| Firmware Version | Unpatched Switches (HAC-001) | Patched Switches (HAC-001) | "New" Switch (HAC-001-01)   | Switch Lite (HDH-001)  | 
 |:--------------|:--------------------------------|:---------------------------|:----------------------------|:-----------------------|
 | 1.0.0         | Nereba or [**RCM**](rcm.md)     | **N/A**                    | **N/A**                     | **N/A**                |
 | 2.0.0 - 3.0.2 | Caffeine or [**RCM**](rcm.md)   | **N/A**                    | **N/A**                     | **N/A**                |
 | 4.0.0 - 4.1.0 | Caffeine or [**RCM**](rcm.md)   | Caffeine                   | **N/A**                     | **N/A**                |
 | 5.0.0 - 7.0.0 | [**RCM**](rcm.md)               | Wait for CFW               | **N/A**                     | **N/A**                |
-| 7.0.1         | [**RCM**](rcm.md)               | Wait for CFW               | Unhackable (currently)      | **N/A**                |
-| 8.0.1 - 9.0.0 | [**RCM**](rcm.md)               | Unhackable (currently)     | Unhackable (currently)      | **N/A**                |
+| 7.0.1         | [**RCM**](rcm.md)               | Wait for CFW               | Wait for exploit            | **N/A**                |
+| 8.0.1         | [**RCM**](rcm.md)               | Wait for exploit           | Wait for exploit            | Wait for exploit       |
+| 8.1.0         | [**RCM**](rcm.md)               | Unhackable (currently)     | Unhackable (currently)      | Unhackable (currently) |
 | >9.0.0        | [**RCM**](rcm.md)               | Unhackable (currently)     | Unhackable (currently)      | Unhackable (currently) |
+
 
 &nbsp;
 

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -79,11 +79,9 @@ The following information is based on [this GBATemp thread](https://gbatemp.net/
 | 2.0.0 - 3.0.2 | Caffeine or [**RCM**](rcm.md)   | **N/A**                    | **N/A**                     | **N/A**                |
 | 4.0.0 - 4.1.0 | Caffeine or [**RCM**](rcm.md)   | Caffeine                   | **N/A**                     | **N/A**                |
 | 5.0.0 - 7.0.0 | [**RCM**](rcm.md)               | Wait for CFW               | **N/A**                     | **N/A**                |
-| 7.0.1         | [**RCM**](rcm.md)               | Wait for CFW               | Wait for exploit            | **N/A**                |
-| 8.0.1         | [**RCM**](rcm.md)               | Wait for exploit           | Wait for exploit            | Wait for exploit       |
-| 8.1.0         | [**RCM**](rcm.md)               | Unhackable (currently)     | Unhackable (currently)      | Unhackable (currently) |
-| >9.0.0        | [**RCM**](rcm.md)               | Unhackable (currently)     | Unhackable (currently)      | Unhackable (currently) |
-
+| 7.0.1         | [**RCM**](rcm.md)               | Wait for CFW               | Update to 8.0.0/1           | **N/A**                |
+| 8.0.1         | [**RCM**](rcm.md)               | Wait for homebrew          | Wait for homebrew           | Wait for homebrew      |
+| 8.1.0 - 9.0.0 | [**RCM**](rcm.md)               | Unhackable (currently)     | Unhackable (currently)      | Unhackable (currently) |
 
 &nbsp;
 

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -79,7 +79,7 @@ The following information is based on [this GBATemp thread](https://gbatemp.net/
 | 2.0.0 - 3.0.2 | Caffeine or [**RCM**](rcm.md)   | **N/A**                    | **N/A**                     | **N/A**                |
 | 4.0.0 - 4.1.0 | Caffeine or [**RCM**](rcm.md)   | Caffeine                   | **N/A**                     | **N/A**                |
 | 5.0.0 - 7.0.0 | [**RCM**](rcm.md)               | Wait for CFW               | **N/A**                     | **N/A**                |
-| 7.0.1         | [**RCM**](rcm.md)               | Wait for CFW               | Update to 8.0.0/1           | **N/A**                |
+| 7.0.1         | [**RCM**](rcm.md)               | Wait for CFW               | Cart update to 8.0.1        | **N/A**                |
 | 8.0.1         | [**RCM**](rcm.md)               | Wait for homebrew          | Wait for homebrew           | Wait for homebrew      |
 | 8.1.0 - 9.0.0 | [**RCM**](rcm.md)               | Unhackable (currently)     | Unhackable (currently)      | Unhackable (currently) |
 


### PR DESCRIPTION
Fix the switch lite’s model number.
Update table of what exploits are available