### PR TITLE
Remove atmosphere-updater

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -36,4 +36,3 @@ This guide was written by staff members of the [Nintendo Homebrew Discord Server
     - **Nexrem (meganukebmp)** for the [Switch 90DNS Tester](https://github.com/meganukebmp/Switch_90DNS_tester).
     - **exelix11** for [Switch Theme Injector](https://github.com/exelix11/SwitchThemeInjector/releases).
     - **vgmoose** for [hb-appstore](https://github.com/vgmoose/hb-appstore).
-    - **ITotalJustice** for [atmosphere-updater](https://github.com/ITotalJustice/atmosphere-updater).

--- a/docs/extras/updating.md
+++ b/docs/extras/updating.md
@@ -8,9 +8,7 @@ After following our guide, your system will consist of three core elements that 
 
 When updating Atmosphere always make sure to _read the release notes_. They may list important changes and modifications to your system.
 
-### Manual method: SD card
-
-When a new version of Atmosphere releases, you can always update Atmosphere by following these steps:
+When a new version of Atmosphere releases, you can update Atmosphere by following these steps:
 
 1. Turn off your Nintendo Switch and plug your SD card in your computer.
 2. Back up `reboot_payload.bin` from the `atmosphere` folder of your SD card to your computer.
@@ -21,35 +19,11 @@ When a new version of Atmosphere releases, you can always update Atmosphere by f
 5. Place your copy of `reboot_payload.bin` in the `atmosphere` folder. If you are prompted to overwrite files, do so.
 6. Put your SD card back in your Switch and launch CFW.
 
-### Automated method: atmosphere-updater
-
-It is also possible to update Atmosphere and Hekate through a homebrew utility called `atmosphere-updater`. This utility should be installed if you followed our guide.
-
-If you did not install this utility, you can download it from <a href="https://github.com/ITotalJustice/atmosphere-updater/releases" target="_blank">here</a> or from the homebrew appstore.
-
-Updating your Atmosphere and Hekate installation using atmosphere-updater:
-
-!!! tip ""
-    - Always update Atmosphere and Hekate together when using atmosphere-updater! Otherwise your `reboot_payload.bin` will not correctly be preserved.
-
-1. Open the Homebrew menu
-2. Open `Atmosphere-Updater`.
-3. Select `Update Hekate (for hekate / kosmos users)`.
-4. Press `A` when prompted.
-5. When asked to update AMS and hekate, press `A`.
-6. When asked to overwrite Atmosphere ini files, press `B`.
-7. Wait for it to complete.
-8. Select `Reboot (reboot to payload)`.
-9. Press `A`.
-10. You can now select your launch option in Hekate.
-
 ## Updating Hekate
 
 When updating Hekate always make sure to _read the release notes_. They may list important changes and modifications to your system.
 
-### Manual method: SD card
-
-When a new version of Hekate releases, you can always update by following these steps:
+When a new version of Hekate releases, you can update by following these steps:
 
 1. Turn off your Nintendo Switch and plug your SD card in your computer.
 2. Download the latest version of <a href="https://github.com/CTCaer/Hekate/releases/" target="_blank">Hekate</a> (Download the `hekate_ctcaer_(version).zip` release of hekate).
@@ -59,33 +33,11 @@ When a new version of Hekate releases, you can always update by following these 
 6. Rename Hekate's `.bin` file to `reboot_payload.bin`.
 7. Put your SD card back in your Switch and launch CFW.
 
-### Automated method: atmosphere-updater
-
-It is also possible to update Atmosphere and Hekate through a homebrew utility called `atmosphere-updater`. This utility should be installed if you followed our guide. 
-
-If you did not install this utility, you can download it from <a href="https://github.com/ITotalJustice/atmosphere-updater/releases" target="_blank">here</a> or from the homebrew appstore.
-
-Updating your Atmosphere and Hekate installation using atmosphere-updater:
-
-!!!tip ""
-    - Always update Atmosphere and Hekate together when using atmosphere-updater! Otherwise your `reboot_payload.bin` will not correctly be preserved.
-
-1. Open the Homebrew menu
-2. Open `Atmosphere-Updater`.
-3. Select `Update Hekate (for hekate / kosmos users)`.
-4. Press `A` when prompted.
-5. When asked to update AMS and hekate, press `A`.
-6. When asked to overwrite Atmosphere ini files, press `B`.
-7. Wait for it to complete.
-8. Select `Reboot (reboot to payload)`.
-9. Press `A`.
-10. You can now select your launch option in Hekate.
-
 ## Updating your firmware
 
 Always check _before_ updating your system firmware if the latest version of Atmosphere _as well_ as the latest version of Hekate support the firmware version you are updating towards.
 
-Currently the latest version supported by Atmosphere and Hekate is: **10.0.1**.
+Currently the latest version supported by Atmosphere and Hekate is: **10.0.2**.
 
 In addition, updating to or past some firmwares update the gamecard firmware. Reference the table below for information about these.
 

--- a/docs/user_guide/emummc/launching_cfw.md
+++ b/docs/user_guide/emummc/launching_cfw.md
@@ -52,4 +52,3 @@ You will now be able to launch the Homebrew Menu by opening the album or by hold
 
     - hbappstore is a homebrew app store where a large collection of switch homebrew is kept.
 
-    - atmosphere-updater is a homebrew app capable of updating Atmosphere. See [this](../../extras/updating.md) page for information on keeping your system up to date.

--- a/docs/user_guide/emummc/sd_preparation.md
+++ b/docs/user_guide/emummc/sd_preparation.md
@@ -26,7 +26,6 @@ Atmosphere has its own bootloader, called fusee (primary). For the purposes of t
     - The latest release of <a href="https://github.com/mtheall/ftpd/releases" target="_blank">FTPD</a> (Download the `ftpd.nro` release of FTPD)
     - The latest release of <a href="https://github.com/exelix11/SwitchThemeInjector/releases" target="_blank">NXThemeInstaller</a> (Download the `NxThemesInstaller.nro` release of NxThemeInstaller)
     - The latest release of <a href="https://github.com/joel16/NX-Shell/releases" target="_blank">NX-Shell</a> (Download the `NX-Shell.nro` release of nx-shell)
-    - The latest release of <a href="https://github.com/ITotalJustice/atmosphere-updater/releases" target="_blank">atmosphere-updater</a>.
     - The latest release of the <a href="https://github.com/vgmoose/hb-appstore/releases" target="_blank">hbappstore</a> (Download the `appstore.nro` release of hbappstore)
 
 ### Instructions
@@ -42,7 +41,7 @@ Atmosphere has its own bootloader, called fusee (primary). For the purposes of t
     8. Copy `hekate_ipl.ini` to the `bootloader` folder on your SD card
     9. Copy `Lockpick_RCM.bin` to the `/bootloader/payloads` folder on your SD card
     10. Create a folder named `appstore` inside the `switch` folder on your SD card, and put `appstore.nro` in it
-    11. Copy `Checkpoint.nro`, `ftpd.nro`, `NX-Shell.nro`, `NxThemesInstaller.nro` and `atmosphere-updater.nro` to the `switch` folder on your SD card
+    11. Copy `Checkpoint.nro`, `ftpd.nro`, `NX-Shell.nro` and `NxThemesInstaller.nro` to the `switch` folder on your SD card
     12. If you were already using your microSD card as a storage device for your games and backed it up before partitioning your microSD card, please place it back on the root of your microSD card.
     13. Reinsert your SD card back into your Switch
 

--- a/docs/user_guide/sysnand/sd_preparation.md
+++ b/docs/user_guide/sysnand/sd_preparation.md
@@ -31,7 +31,6 @@ Atmosphere has its own bootloader, called fusee (primary). For the purposes of t
     - The latest release of <a href="https://github.com/mtheall/ftpd/releases" target="_blank">FTPD</a> (Download the `ftpd.nro` release of FTPD)
     - The latest release of <a href="https://github.com/exelix11/SwitchThemeInjector/releases" target="_blank">NXThemeInstaller</a> (Download the `NxThemesInstaller.nro` release of NxThemeInstaller)
     - The latest release of <a href="https://github.com/joel16/NX-Shell/releases" target="_blank">NX-Shell</a> (Download the `NX-Shell.nro` release of nx-shell)
-    - The latest release of <a href="https://github.com/ITotalJustice/atmosphere-updater/releases" target="_blank">atmosphere-updater</a>.
     - The latest release of the <a href="https://github.com/vgmoose/hb-appstore/releases" target="_blank">hbappstore</a> (Download the `appstore.nro` release of hbappstore)
 
 
@@ -48,7 +47,7 @@ Atmosphere has its own bootloader, called fusee (primary). For the purposes of t
     8. Copy `hekate_ipl.ini` to the `bootloader` folder on your SD card
     9. Copy `Lockpick_RCM.bin` to the `/bootloader/payloads` folder on your SD card
     10. Create a folder named `appstore` inside the `switch` folder on your SD card, and put `appstore.nro` in it
-    11. Copy `Checkpoint.nro`, `ftpd.nro`, `NX-Shell.nro`, `NxThemesInstaller.nro` and `atmosphere-updater.nro` to the `switch` folder on your SD card
+    11. Copy `Checkpoint.nro`, `ftpd.nro`, `NX-Shell.nro` and `NxThemesInstaller.nro` to the `switch` folder on your SD card
     12. Reinsert your SD card back into your Switch
 
      ![sdfilesimg](../img/sdfiles.png)


### PR DESCRIPTION
Closes #116.

It's deprecated and we barely recommend using it anyway.