### PR TITLE
Add instructions to install udev rules via package (nx-udev)

### DIFF
--- a/docs/extras/adding_udev.md
+++ b/docs/extras/adding_udev.md
@@ -3,17 +3,22 @@
 This section details how to add an udev rule to let you send a payload to the Nintendo Switch without needing to use `sudo`.
 
 !!! tip ""
-    The following instructions are not for beginners. Only do this if you are confident in what you are doing.
-
-!!! tip ""
     The following instructions only work if you have a system that implements `udev`. Most modern distros come with `systemd` already installed, which includes a `udev` implementation.
-
-    There are differing implementations of the following commands on different distros. The commands below are assumed to be ran on Ubuntu. Check your distros manual if you are not running Ubuntu for the equivalent commands.
 
 !!! tip ""
     Do the following instructions while your Switch is _not_ connected to your computer.
 
-## Creating a new group
+&nbsp;
+
+## Option 1: Manually adding rules and group
+
+!!! tip ""
+    The following instructions are not for beginners. Only do this if you are confident in what you are doing.
+
+!!! tip ""
+    There are differing implementations of the following commands on different distros. The commands below are assumed to be ran on Ubuntu. Check your distros manual if you are not running Ubuntu for the equivalent commands.
+
+### Creating a new group
 
 To start, we will create a new group and add ourselves to it. The group the Nintendo Switch device will be owned by on Linux will be set to this group.
 
@@ -23,7 +28,7 @@ To start, we will create a new group and add ourselves to it. The group the Nint
 4. Enter the following command: `sudo usermod -a -G nintendo_switch $USER`. Make sure that the `G` is capitalized!
 5. Close the terminal.
 
-## Adding a udev rule
+### Adding a udev rule
 
 Next we're gonna add a new udev rule. udev is a device manager for the linux kernel. The rule we're gonna specify is that if the Switch is connected in RCM mode, the group the Switch belongs to will be the group we made in the previous section.
 
@@ -36,3 +41,19 @@ Next we're gonna add a new udev rule. udev is a device manager for the linux ker
 7. Logout and log back in.
 
 You should now be able to run the payload sender without having to use `sudo`.
+
+&nbsp;
+
+## Option 2: Installing a package with the rules
+
+!!! tip ""
+    These rules will actually allow _ANY_ user to access your switch via USB, not only your user.
+
+You may just follow the instructions at <a href="https://github.com/pheki/nx-udev" target="_blank">nx-udev</a>, or if you're on Ubuntu / Debian:
+
+1. Download <a href="https://github.com/pheki/nx-udev/releases/latest/download/nx-udev_latest_all.deb
+" target="_blank">nx-udev_latest_all.deb</a>.
+2. Open a terminal in the same directory as your download.
+3. Run `sudo dpkg -i nx-udev_latest_all.deb` to install the package
+
+You should now be able to run the payload injector and homebrew with USB communication without having to use `sudo`.

--- a/docs/user_guide/emummc/sending_payload.md
+++ b/docs/user_guide/emummc/sending_payload.md
@@ -53,7 +53,7 @@ Now that the device is in RCM, we will need to send it a payload. The methods ar
 ### Instructions
 
 !!! tip ""
-    1. Download and run the payload injector (if you are on Linux, you will need to run this program as root or use `sudo`).
+    1. Download and run the payload injector (if you're on Linux, you will need to run this program as root, use `sudo`, or follow the instructions at [Linux injection without root](../../extras/adding_udev.md)).
     2. Connect your Switch in RCM to your PC using the USB cable.
     3. Wait for your Switch to be shown as found in the injector.
     4. Press `Select Payload`, and navigate to and select your payload `.bin` file.

--- a/docs/user_guide/emummc/sending_payload.md
+++ b/docs/user_guide/emummc/sending_payload.md
@@ -3,7 +3,7 @@
 # Sending a Payload
 
 !!! warning "If you are here to test if your Switch is patched"
-    Make sure you have [put your device into RCM](../emummc/entering_rcm.md) and downloaded Hekate (if necessary, extract its zip file onto the root of your SD card) before continuing. Once finished, if your console is **not** patched, continue with [Partitioning the SD](../emummc/partitioning_sd.md) instead of `Making the emuMMC` at the end of this page.
+    Make sure you have [put your device into RCM](entering_rcm.md) and downloaded Hekate (if necessary, extract its zip file onto the root of your SD card) before continuing. Once finished, if your console is **not** patched, continue with [Partitioning the SD](partitioning_sd.md) instead of `Making the emuMMC` at the end of this page.
 
 
 Now that the device is in RCM, we will need to send it a payload. The methods are mostly the same, but slightly differ depending on what hardware you have available.

--- a/docs/user_guide/sysnand/sending_payload.md
+++ b/docs/user_guide/sysnand/sending_payload.md
@@ -43,7 +43,7 @@ Now that the device is in RCM, we will need to send it a payload. The methods ar
 ### Instructions
 
 !!! tip ""
-    1. Download and run the payload injector (if you are on Linux, you will need to run this program as root or use `sudo`.)
+    1. Download and run the payload injector (if you're on Linux, you will need to run this program as root, use `sudo`, or follow the instructions at [Linux injection without root](../../extras/adding_udev.md)).
     2. Connect your Switch in RCM to your PC using the USB cable
     3. Wait for your Switch to be shown as found in the injector
     4. Press `Select Payload`, and navigate to and select your hekate_ctcaer `.bin` file


### PR DESCRIPTION
Hey!

I've added instructions on "Linux injection without root" on how to install the udev rules via package if preferred (using [nx-udev](https://github.com/pheki/nx-udev)).

I've also added a link to that page from "sending_payload.md" as its kind of hard to find and Wayland (which is the default window compositor in Debian, AFAIK also Ubuntu) won't allow GUI apps to be run with root permissions.

As a bonus, I flattened some links (from `../emummc/entering_rcm.md` to `entering_rcm.md`), I hope its OK.