### PR TITLE
Use hekate's reboot to payload updater

### DIFF
--- a/docs/extras/updating.md
+++ b/docs/extras/updating.md
@@ -10,7 +10,7 @@ When updating Atmosphere always make sure to _read the release notes_. They may 
 
 When a new version of Atmosphere releases, you can update Atmosphere by following these steps:
 
-1. Launch Hekate, and go to the Options tab at the top right of the screen. Turn "Update Reboot 2 Payload" on the bottom right ON.
+1. Launch Hekate, and go to the Options tab at the top right of the screen. Turn "Update Reboot 2 Payload" on the bottom right ON (if it isn't on already).
 2. Tap "Save Options" at the bottom of the screen.
 2. Turn off your Nintendo Switch and plug your SD card in your computer.
 3. Download the latest release of <a href="https://github.com/Atmosphere-NX/Atmosphere/releases" target="_blank">Atmosphere</a> (Download the `atmosphere-(version).zip` release of Atmosphere.)
@@ -25,7 +25,7 @@ When updating Hekate always make sure to _read the release notes_. They may list
 
 When a new version of Hekate releases, you can update by following these steps:
 
-1. Launch Hekate, and go to the Options tab at the top right of the screen. Turn "Update Reboot 2 Payload" on the bottom right ON.
+1. Launch Hekate, and go to the Options tab at the top right of the screen. Turn "Update Reboot 2 Payload" on the bottom right ON (if it isn't on already).
 2. Tap "Save Options" at the bottom of the screen.
 3. Turn off your Nintendo Switch and plug your SD card in your computer.
 4. Download the latest version of <a href="https://github.com/CTCaer/Hekate/releases/" target="_blank">Hekate</a> (Download the `hekate_ctcaer_(version).zip` release of hekate).

--- a/docs/extras/updating.md
+++ b/docs/extras/updating.md
@@ -10,14 +10,14 @@ When updating Atmosphere always make sure to _read the release notes_. They may 
 
 When a new version of Atmosphere releases, you can update Atmosphere by following these steps:
 
-1. Turn off your Nintendo Switch and plug your SD card in your computer.
-2. Back up `reboot_payload.bin` from the `atmosphere` folder of your SD card to your computer.
+1. Launch Hekate, and go to the Options tab at the top right of the screen. Turn "Update Reboot 2 Payload" on the bottom right ON.
+2. Tap "Save Options" at the bottom of the screen.
+2. Turn off your Nintendo Switch and plug your SD card in your computer.
 3. Download the latest release of <a href="https://github.com/Atmosphere-NX/Atmosphere/releases" target="_blank">Atmosphere</a> (Download the `atmosphere-(version).zip` release of Atmosphere.)
 4. Copy *the contents of* the Atmosphere `.zip` file to the root of your SD card.
     - If you are prompted to overwrite files, do so, _except_ for the `.ini` files.
     - If you do accidentally overwrite the `.ini` files, this is not an emergency but you will lose any changes you made to Atmospheres settings.
-5. Place your copy of `reboot_payload.bin` in the `atmosphere` folder. If you are prompted to overwrite files, do so.
-6. Put your SD card back in your Switch and launch CFW.
+5. Put your SD card back in your Switch and launch CFW.
 
 ## Updating Hekate
 
@@ -25,13 +25,12 @@ When updating Hekate always make sure to _read the release notes_. They may list
 
 When a new version of Hekate releases, you can update by following these steps:
 
-1. Turn off your Nintendo Switch and plug your SD card in your computer.
-2. Download the latest version of <a href="https://github.com/CTCaer/Hekate/releases/" target="_blank">Hekate</a> (Download the `hekate_ctcaer_(version).zip` release of hekate).
-3. Copy the `bootloader` folder from the Hekate `.zip` file to the root of your SD card. If you are asked to overwrite or merge files while copying, say yes to merge/overwrite them.
-4. Copy Hekate's `.bin` file from the Hekate `.zip` file to the `atmosphere` folder on your SD card.
-5. If you already have `reboot_payload.bin` in the `atmosphere` folder on your SD card, delete it.
-6. Rename Hekate's `.bin` file to `reboot_payload.bin`.
-7. Put your SD card back in your Switch and launch CFW.
+1. Launch Hekate, and go to the Options tab at the top right of the screen. Turn "Update Reboot 2 Payload" on the bottom right ON.
+2. Tap "Save Options" at the bottom of the screen.
+3. Turn off your Nintendo Switch and plug your SD card in your computer.
+4. Download the latest version of <a href="https://github.com/CTCaer/Hekate/releases/" target="_blank">Hekate</a> (Download the `hekate_ctcaer_(version).zip` release of hekate).
+5. Copy the `bootloader` folder from the Hekate `.zip` file to the root of your SD card. If you are asked to overwrite or merge files while copying, say yes to merge/overwrite them.
+6. Put your SD card back in your Switch and launch CFW.
 
 ## Updating your firmware
 

--- a/docs/files/emu/hekate_ipl.ini
+++ b/docs/files/emu/hekate_ipl.ini
@@ -1,3 +1,5 @@
+[config]
+updater2p=1
 {------ Atmosphere ------}
 [Atmosphere FSS0 EmuMMC]
 fss0=atmosphere/fusee-secondary.bin

--- a/docs/files/sys/hekate_ipl.ini
+++ b/docs/files/sys/hekate_ipl.ini
@@ -1,3 +1,5 @@
+[config]
+updater2p=1
 {------ Atmosphere ------}
 [Atmosphere FSS0 SYS]
 fss0=atmosphere/fusee-secondary.bin

--- a/docs/user_guide/emummc/sd_preparation.md
+++ b/docs/user_guide/emummc/sd_preparation.md
@@ -33,15 +33,12 @@ Atmosphere has its own bootloader, called fusee (primary). For the purposes of t
     3. Copy the `bootloader` folder from the Hekate `.zip` file to the root of your SD card
     4. Copy the `bootloader` folder from the `bootlogos.zip` file to the root of your SD card
        - If you're asked to merge the bootloader folders, do so
-    5. Copy Hekate's `.bin` file from the Hekate `.zip` file to the `atmosphere` folder on your SD card
-    6. Delete `reboot_payload.bin` in the `atmosphere` folder on your SD card
-    7. Rename Hekate's `.bin` file to `reboot_payload.bin`
-    8. Copy `hekate_ipl.ini` to the `bootloader` folder on your SD card
-    9. Copy `Lockpick_RCM.bin` to the `/bootloader/payloads` folder on your SD card
-    10. Create a folder named `appstore` inside the `switch` folder on your SD card, and put `appstore.nro` in it
-    11. Copy `Checkpoint.nro`, `ftpd.nro`, `NX-Shell.nro` and `NxThemesInstaller.nro` to the `switch` folder on your SD card
-    12. If you were already using your microSD card as a storage device for your games and backed it up before partitioning your microSD card, please place it back on the root of your microSD card.
-    13. Reinsert your SD card back into your Switch
+    5. Copy `hekate_ipl.ini` to the `bootloader` folder on your SD card
+    6. Copy `Lockpick_RCM.bin` to the `/bootloader/payloads` folder on your SD card
+    7. Create a folder named `appstore` inside the `switch` folder on your SD card, and put `appstore.nro` in it
+    8. Copy `Checkpoint.nro`, `ftpd.nro`, `NX-Shell.nro` and `NxThemesInstaller.nro` to the `switch` folder on your SD card
+    9. If you were already using your microSD card as a storage device for your games and backed it up before partitioning your microSD card, please place it back on the root of your microSD card.
+    10. Reinsert your SD card back into your Switch
 
     !!! tip ""
         Your SD card should look similar to this. The `Nintendo` folder will not be present if your switch has not already booted with the microSD card inserted.

--- a/docs/user_guide/sysnand/sd_preparation.md
+++ b/docs/user_guide/sysnand/sd_preparation.md
@@ -38,14 +38,11 @@ Atmosphere has its own bootloader, called fusee (primary). For the purposes of t
     3. Copy the `bootloader` folder from the Hekate `.zip` file to the root of your SD card
     4. Copy the `bootloader` folder from the `bootlogos.zip` file to the root of your SD card
        - If you're asked to merge the bootloader folders, do so
-    5. Copy Hekate's `.bin` file from the Hekate `.zip` file to the `atmosphere` folder on your SD card
-    6. Delete `reboot_payload.bin` in the `atmosphere` folder on your SD card
-    7. Rename Hekate's `.bin` file to `reboot_payload.bin`
-    8. Copy `hekate_ipl.ini` to the `bootloader` folder on your SD card
-    9. Copy `Lockpick_RCM.bin` to the `/bootloader/payloads` folder on your SD card
-    10. Create a folder named `appstore` inside the `switch` folder on your SD card, and put `appstore.nro` in it
-    11. Copy `Checkpoint.nro`, `ftpd.nro`, `NX-Shell.nro` and `NxThemesInstaller.nro` to the `switch` folder on your SD card
-    12. Reinsert your SD card back into your Switch
+    5. Copy `hekate_ipl.ini` to the `bootloader` folder on your SD card
+    6. Copy `Lockpick_RCM.bin` to the `/bootloader/payloads` folder on your SD card
+    7. Create a folder named `appstore` inside the `switch` folder on your SD card, and put `appstore.nro` in it
+    8. Copy `Checkpoint.nro`, `ftpd.nro`, `NX-Shell.nro` and `NxThemesInstaller.nro` to the `switch` folder on your SD card
+    9. Reinsert your SD card back into your Switch
 
     !!! tip ""
         Your SD card should look similar to this. The `Nintendo` folder will not be present if your switch has not already booted with the microSD card inserted.


### PR DESCRIPTION
Use hekate's r2p updater so updating the atmosphere/reboot_payload.bin manually is no longer required