### PR TITLE
Fix iOS/NXBoot hardware requirements list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ A guide collaboration between Nintendo Homebrew's Helpers and Staff, from stock 
     - A USB-OTG cable, a USB-A to USB-C cable, and an Android device
 		- This does not work on every android phone
     - A USB-C cable, and an Android device with a USB-C port
-    - A Lightning to USB-C cable, and a jailbroken iOS device
+    - A Lightning-OTG adapter, a USB-A to USB-C cable, and a jailbroken iOS device
         - This method is not covered by the guide, but you can read more about it at [this website](https://mologie.github.io/nxboot/)
 
 


### PR DESCRIPTION
Hey! Author of NXBoot for iOS here. My iOS payload injector NXBoot does not work with a Lightning to USB-C cable, but your guide claims it does. This causes an occasional email in my inbox that could be avoided :). This pull request updates the guide to fix the iOS hardware requirement list. Cheers, Oliver.