### PR TITLE
Clarify warning for keeping emuMMC offline

### DIFF
--- a/docs/user_guide/emummc/launching_cfw.md
+++ b/docs/user_guide/emummc/launching_cfw.md
@@ -7,7 +7,7 @@ Unlike systems such as the DSi, Wii, or 3DS, Switch CFW is currently volatile. I
 &nbsp;
 
 !!! danger "Keep emuMMC offline at all times"
-    Your emuMMC (emuNAND) should never connect to Nintendo. For online play, eShop browsing, or any other Nintendo online activity, use your sysNAND. Using both emuMMC and sysNAND online will likely result in a ban.
+    Your emuMMC (emuNAND) should never connect to Nintendo. Use your sysNAND for online play, eShop browsing, or any other Nintendo online activity. Using emuMMC online will likely result in a ban.
 
 ### Instructions
 


### PR DESCRIPTION
The current warming's usage of "both emuMMC and sysNAND" is a bit unclear. The first two sentences seem say emuMMC should stay offline while the sysNAND can connect online, but the final sentence makes emuMMC and sysNAND sound interchangeable.