### PR TITLE
Updated instructions on migration to different SD

### DIFF
--- a/docs/extras/transfer_sd.md
+++ b/docs/extras/transfer_sd.md
@@ -22,7 +22,9 @@ You should first check whether you have a file or partition based emuMMC:
 4.  Eject the SD card and insert your new one.
 5.  Format your new SD card to FAT32 if it isn’t already.
     - To do this, use [guiformat](http://ridgecrop.co.uk/index.htm?guiformat.htm) for example (Windows).
-6.  Copy the files from your PC to your new SD card and you’re done.
+6.  Copy the files from your PC to your new SD card and insert it into the console.
+7.  Boot into Hekate, then press `Tools` -> `Arch bit • RCM Touch • Pkg1/2` -> `Fix Archive Bit`
+8.  Wait for the process to finish and you're done!
 
 -----
 ### If you are using a partition based emummc:


### PR DESCRIPTION
For the file based emunand I've added the step with the fix of the archive bit
Some users may have issues with lost archive bits during the file-transfer. 
I believe it is OS dependent, I've encountered this issue on MacOS, so it also may occur for linux. 
If that happens - emunand boots alright but all the applications are unable to start, performing the `Fix Archive Bit` in hekate helps with that issue.
Though this step is not mandatory for all cases (should be ok with windows) - I've added it as a last step since it'll do no harm even when not necessary, but on the other side the following sequence of actions should leave end-user with a working system no matter what was used for the file-transfer.