### PR TITLE
Remove unnecessary lines from hekate_ipl.ini and improve config readability 

### DIFF
--- a/docs/extras/transfer_sd.md
+++ b/docs/extras/transfer_sd.md
@@ -46,4 +46,4 @@ You should first check whether you have a file or partition based emuMMC:
 14. Restore the backup by tapping on both `SD emuMMC BOOT0 & BOOT1` and `SD emuMMC RAW GPP` (Note: raw gpp may take a while).
     - It is very important that for both of these the `SD emuMMC Raw Partition` option is enabled, otherwise you will be altering your sysMMC
       which is not what you want.
-15. Your emuMMC is now restored on the new SD card and you should be able to launch it from `Launch` -> `Atmosphere FSS0 EmuMMC`  in hekate.
+15. Your emuMMC is now restored on the new SD card and you should be able to launch it from `Launch` -> `Atmosphere FSS0 emuMMC` in hekate.

--- a/docs/extras/updating.md
+++ b/docs/extras/updating.md
@@ -101,7 +101,7 @@ If you keep your emuMMC offline, you will have to use a gamecard to update your 
 
 ### Updating your emuMMC with Daybreak
 
-1. In Hekate go to `Launch -> Atmosphere FSS0 Emu`.
+1. In Hekate go to `Launch -> Atmosphere FSS0 emuMMC`.
 2. Once booted, hold `R` while launching a game to boot into the homebrew menu.
 3. Find Daybreak in the homebrew menu and launch it.
 4. Tap on `Install` and navigate to `tegraexplorer/Firmware/<latest firmware number>`.

--- a/docs/files/emu/hekate_ipl.ini
+++ b/docs/files/emu/hekate_ipl.ini
@@ -1,21 +1,20 @@
 [config]
 updater2p=1
-{------ Atmosphere ------}
-[Atmosphere FSS0 EmuMMC]
+
+[Atmosphere FSS0 emuMMC]
 fss0=atmosphere/package3
 kip1=atmosphere/kips/*
 emummcforce=1
 icon=bootloader/res/emu_boot.bmp
-{}
-[Atmosphere FSS0 SYS]
+
+[Atmosphere FSS0 sysMMC]
 fss0=atmosphere/package3
 kip1=atmosphere/kips/*
 emummc_force_disable=1
 icon=bootloader/res/sys_cfw_boot.bmp
-{}
-{-------- Stock ---------}
-[Stock SYS]
+
+[Stock sysMMC]
 fss0=atmosphere/package3
-stock=1
 emummc_force_disable=1
+stock=1
 icon=bootloader/res/stock_boot.bmp

--- a/docs/files/sys/hekate_ipl.ini
+++ b/docs/files/sys/hekate_ipl.ini
@@ -1,15 +1,14 @@
 [config]
 updater2p=1
-{------ Atmosphere ------}
-[Atmosphere FSS0 SYS]
+
+[Atmosphere FSS0 sysMMC]
 fss0=atmosphere/package3
 kip1=atmosphere/kips/*
 emummc_force_disable=1
 icon=bootloader/res/sys_cfw_boot.bmp
-{}
-{-------- Stock ---------}
-[Stock SYS]
+
+[Stock sysMMC]
 fss0=atmosphere/package3
-stock=1
 emummc_force_disable=1
+stock=1
 icon=bootloader/res/stock_boot.bmp

--- a/docs/user_guide/emummc/launching_cfw.md
+++ b/docs/user_guide/emummc/launching_cfw.md
@@ -14,7 +14,7 @@ Unlike systems such as the DSi, Wii, or 3DS, Switch CFW is currently volatile. I
 !!! tip ""
     1. Power on your Switch into RCM, and inject the Hekate payload
     2. Navigate to `Launch` using the touch screen
-    3. Find `Atmosphere FSS0 EmuMMC` and launch it
+    3. Find `Atmosphere FSS0 emuMMC` and launch it
 
 Your Switch is now booting into Atmosphere.
 

--- a/docs/user_guide/sysnand/launching_cfw.md
+++ b/docs/user_guide/sysnand/launching_cfw.md
@@ -11,7 +11,7 @@ Unlike systems such as the DSi, Wii, or 3DS, Switch CFW is currently volatile. I
 !!! tip ""
     1. Power on your Switch into RCM, and inject the Hekate payload
     2. Navigate to `Launch` using the touch screen
-    3. Find `Atmosphere FSS0 SYS` and launch it
+    3. Find `Atmosphere FSS0 sysMMC` and launch it
 
 Your Switch is now booting into Atmosphere.
 


### PR DESCRIPTION
The spacing of hekate_ipl.ini provided by the guide makes it confusing to read at first glance, like using {} instead of just a blank line to separate sections.

The naming scheme is inconsistent. We have  Atmosphere FSS0 SYS and Atmosphere FSS0 emuMMC. Sys is also an emmc chip, so wouldn't it be more appropriate to have it say Atmosphere FSS0 sysMMC to match the naming of emu?

This is an example of my proposed config included in this PR to fix the mentioned issues, and merge into the main branch: (both emu and sys .ini's have been updated)

```
[config]
updater2p=1

[Atmosphere FSS0 emuMMC]
fss0=atmosphere/package3
kip1=atmosphere/kips/*
emummcforce=1
icon=bootloader/res/emu_boot.bmp

[Atmosphere FSS0 sysMMC]
fss0=atmosphere/package3
kip1=atmosphere/kips/*
emummc_force_disable=1
icon=bootloader/res/sys_cfw_boot.bmp

[Stock sysMMC]
fss0=atmosphere/package3
emummc_force_disable=1
stock=1
icon=bootloader/res/stock_boot.bmp
```