### PR TITLE
Update SD Transfer to match current Hekate

### DIFF
--- a/docs/extras/transfer_sd.md
+++ b/docs/extras/transfer_sd.md
@@ -39,7 +39,7 @@ You should first check whether you have a file or partition based emuMMC:
 7.  Follow only [this page](https://switchgui.de/switch-guide/user_guide/emummc/partitioning_sd/) to partition the new SD card for an emuMMC setup.
 8.  After it’s done, exit and insert your new SD card into your PC.
 9.  Copy the contents of your old SD card to your new one.
-10. Navigate to `/backup/<some characters>/` on your SD card and move `BOOT0`, `BOOT1` and the `rawnand.bin.xx` files to the `restore` folder.
+10. Navigate to `/backup/<some characters>/` on your SD card and move `BOOT0`, `BOOT1` and the `rawnand.bin.xx` files to the `/backup/<some characters>/restore/emummc` folder.
 11. Eject the SD card and insert it into your switch.
 12. Inject the hekate payload once again.
 13. Tap on `Tools`, `Restore eMMC`, set `SD emuMMC Raw Partition` at the bottom of your screen to `ON`.


### PR DESCRIPTION
Hekate now restores emummc from the `restore/emummc/` folder so this just updates it to say that.