### PR TITLE
Added reference to savefileconverter, which can convert game saves to and from NSO format

### DIFF
--- a/docs/extras/save_management.md
+++ b/docs/extras/save_management.md
@@ -4,6 +4,8 @@ For save management, [JKSV](https://github.com/J-D-K/JKSV) is recommended. It ca
 
 [Checkpoint](https://github.com/FlagBrew/Checkpoint) is also a save manager. It can be used to back up and restore game saves to your SD card. It also has the ability to share save data over FTP and WiFi.
 
+[savefileconverter.com](https://savefileconverter.com/#/nintendo-switch-online) can be used to convert game saves back and forth to raw/emulator format. It can also convert saves to and from the MiSTer, flash carts, online emulators, and other formats.
+
 &nbsp;
 	
 ### JKSV


### PR DESCRIPTION
Added a blurb to the Save Management page about https://savefileconverter.com/#/nintendo-switch-online which can convert saves to and from NSO format (assuming the user has access to CFW).

The site is free, contains no advertising, and is completely open source: https://github.com/euan-forrester/save-file-converter

Info about NSO save formats can be found here: https://github.com/euan-forrester/save-file-converter/tree/main/frontend/src/save-formats/NintendoSwitchOnline