### PR TITLE
Migrate fully to GitHub Actions for Pages deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v3
+
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
@@ -41,14 +44,25 @@ jobs:
         # Build the site using mkdocs
         run: mkdocs build --verbose --clean --strict
 
-      - name: Post-Mkdocs touch/copy files
-        # miscellaneous files needed for GitHub etc
-        run: |
-          touch site/.nojekyll
-
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: site # The folder the action should deploy.
-          clean: true # Automatically remove deleted files from the deploy branch
+          path: "site"
+
+  # Deployment job
+  deploy:
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: doc-deploy
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Legacy deploy environments (including simply having something in gh-pages!) is deprecated.

GitHub really wants us to use their deploy-pages system for this, so switch to it.