### PR TITLE
Clone SSNC to a separate page

### DIFF
--- a/docs/user_guide/rcm_supported_devices.md
+++ b/docs/user_guide/rcm_supported_devices.md
@@ -1,0 +1,17 @@
+# Devices that support sending a payload over RCM
+
+### Serial list
+
+The following information is based on [this GBATemp thread](https://gbatemp.net/threads/switch-informations-by-serial-number-read-the-first-post-before-asking-questions.481215/).
+
+|  Serial Numbers  | <span style="color:green">Unpatched</span> | <span style="color:orange">Potentially patched</span> | <span style="color:red">Patched</span> |
+| :----|:---------------------------------|:---------------------------------|:----------------------|
+| XAW1 | XAW10000000000 to XAW10074000000 | XAW10074000000 to XAW10120000000 | XAW10120000000 and up |
+| XAW4 | XAW40000000000 to XAW40011000000 | XAW40011000000 to XAW40012000000 | XAW40012000000 and up |
+| XAW7 | XAW70000000000 to XAW70017800000 | XAW70017800000 to XAW70030000000 | XAW70030000000 and up |
+| XAJ1 | XAJ10000000000 to XAJ10020000000 | XAJ10020000000 to XAJ10030000000 | XAJ10030000000 and up |
+| XAJ4 | XAJ40000000000 to XAJ40046000000 | XAJ40046000000 to XAJ40060000000 | XAJ40060000000 and up |
+| XAJ7 | XAJ70000000000 to XAJ70040000000 | XAJ70040000000 to XAJ70050000000 | XAJ70050000000 and up |
+| XAK1 | **N/A** | XAK10000000000 and up | **N/A** |
+
+If your serial number is not listed above, your device is not vulnerable.


### PR DESCRIPTION
I'm not sure if this is a good idea. Essentially I wanted a quick and easy way to link users to the big ol' table of serial numbers, nothing more than that.