### PR TITLE
Migrate to switch.hacks.guide

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
         # miscellaneous files needed for GitHub etc
         run: |
           touch site/.nojekyll
+          cp CNAME site/CNAME
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.4.1

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+switch.hacks.guide

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: NH Switch Guide
 copyright: Copyright &copy; 2024 <a href="https://discord.gg/C29hYvh" target="_blank">Nintendo Homebrew</a>, Maintained by the <a href="/switch-guide/about">NH Discord Server</a>.
 site_description: Switch CFW Guide.
 site_author: NH Discord Server.
-site_url: https://nh-server.github.io/switch-guide/
+site_url: https://switch.hacks.guide
 repo_url: https://github.com/nh-server/switch-guide
 repo_name: NH Switch Guide
 


### PR DESCRIPTION
Didn't really verify if this works right away.

The DNS is already set up; seems HTTPS isn't set up? Someone with settings perms can mess with that when they merge I suppose