### PR TITLE
Updated Build Instructions to Reflect the VitePress Overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,24 @@
 
 Nintendo Switch homebrew guide written by staff members of the Nintendo Homebrew Discord server.
 
-## Development
-You will need Python 3 installed as well as pip3. The [mkdocs website](https://www.mkdocs.org) will explain how to do this, and how to install mkdocs. This guide was developed on Python 3.6 and 3.7.
+## Running the site locally
 
-After cloning the repository, you can install all the needed dependancies (including mkdocs) with this command, ran in the project's directory: `pip3 install --user -r requirements.txt`
+This requires the following installed on your system:
 
-Please take some time to familiarize yourself with mkdocs. [The site will detail everything for you.](https://www.mkdocs.org/#getting-started)
+* [node.js](https://nodejs.org/en)
+
+To test the website locally, clone the source code:
+
+```bash
+git clone https://github.com/nh-server/switch-guide.git --recurse-submodules
+cd switch-guide
+```
+
+Then simply run the following commands:
+
+```bash
+npm ci
+npm run docs:dev
+```
+
+The website should now be running on http://127.0.0.1:5173/ (or a port shown on the terminal). Any edits you make should appear live!


### PR DESCRIPTION
Rewrote the build instructions to function properly after the guide switched from mkdocs to VitePress.