### PR TITLE
Remove SciresM Warning + Change "any button"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,18 +30,6 @@ Additionally, we are not currently, historically, or will ever be, associated wi
 
 :::
 
-::: danger
-
-<span style="font-size: 30px;">**Important Notice**</span>
-
-As of January 26th, 2026, the sole maintainer of Atmosphère, SciresM, has announced that they are [retiring from the public hacking scene](https://gist.github.com/SciresM/e760b192d873af67ce8f0f5c7000a651). Since they have retired, Atmosphère updates will likely take longer to release when future Nintendo Switch firmware updates arrive. What this means is that, currently, firmware version `21.2.0` is the latest (officially) supported firmware, without any potential uncertainty.
-
-Users should be cautious when considering updating past firmware version `21.2.0`. Atmosphère may not function on newer firmware versions if Nintendo implements any major changes.
-
-In addition, due to the longer duration between updates, there is a large likelihood of **potentially dangerous** Atmosphère forks coming into existence. Users are advised **NOT** to use these forks, and should wait for proper Atmosphère updates from team members that are trusted and knowledgeable.
-
-:::
-
 ## What do I need to know before starting?
 
 This page will explore:

--- a/docs/user_guide/rcm/sending_payload.md
+++ b/docs/user_guide/rcm/sending_payload.md
@@ -226,7 +226,7 @@ Later in the guide, you will be formatting and/or partitioning your microSD card
 1. Inside the extracted hekate folder you will find a folder named `bootloader`.
 1. Copy the `bootloader` folder to the root of your microSD card.
 1. Put your microSD card back into your Switch.
-1. Press any button to continue to the hekate menu.
+1. Press either volume button or power to continue to the hekate menu.
 1. Use volume up and volume down to navigate the hekate menu. Hover over 'load nyx' and press the power button to select. Your screen should now have the hekate GUI (Nyx) pictured below.
 
     ![Nyx](../all/img/nyx.bmp){ width="600" }


### PR DESCRIPTION
- Removed warning regarding SciresM on the home page.
- Changed "any button" to refer to either volume button or power.