### PR TITLE
Update nx shell

### DIFF
--- a/docs/homebrew/nx-shell.md
+++ b/docs/homebrew/nx-shell.md
@@ -14,7 +14,7 @@ NX-Shell is a file manager.
 
 :::
 
-More information can be found on the [NX-Shell GitHub](https://github.com/joel16/NX-Shell) repository.
+More information can be found on the [NX-Shell GitHub](https://github.com/DefenderOfHyrule/NX-Shell/releases) repository.
 
 ## NX-Shell screenshots
 

--- a/docs/homebrew/nx-shell.md
+++ b/docs/homebrew/nx-shell.md
@@ -14,7 +14,7 @@ NX-Shell is a file manager.
 
 :::
 
-More information can be found on the [NX-Shell GitHub](https://github.com/DefenderOfHyrule/NX-Shell/releases) repository.
+More information can be found on the [NX-Shell GitHub](https://github.com/DefenderOfHyrule/NX-Shell/) repository.
 
 ## NX-Shell screenshots
 

--- a/docs/user_guide/all/sd_preparation.md
+++ b/docs/user_guide/all/sd_preparation.md
@@ -22,7 +22,7 @@ If you use Windows, you should enable file name extensions before continuing. Se
 * The latest release of [JKSV](https://github.com/J-D-K/JKSV/releases) (Download the `JKSV.nro` release of JKSV)
 * The latest release of [FTPD](https://github.com/mtheall/ftpd/releases) (Download the `ftpd.nro` release of FTPD)
 * The latest release of [NXThemesInstaller](https://github.com/exelix11/SwitchThemeInjector/releases) (Download the `NXThemesInstaller.nro` release of NXThemesInstaller)
-* The latest release of [NX-Shell](https://github.com/joel16/NX-Shell/releases) (Download the `NX-Shell.nro` release of nx-shell)
+* The latest release of [NX-Shell](https://github.com/DefenderOfHyrule/NX-Shell/releases) (Download the `NX-Shell.nro` release of nx-shell)
 * The latest release of [Goldleaf](https://github.com/XorTroll/Goldleaf/releases) (Download the `Goldleaf.nro` release of Goldleaf)
 
 ::: danger


### PR DESCRIPTION
changes the nx-shell link to the updated abi version. i think i got all the instances of the link.